### PR TITLE
Add :nomore_files to return stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# ZipStream [![Build Status](https://api.travis-ci.org/awetzel/zip_stream.svg)][Continuous Integration]
-
-[Continuous Integration]: http://travis-ci.org/awetzel/zip_stream "Build status by Travis-CI"
+# ZipStream
 
 Library to read zip file in a stream.
 Zip file binary stream -> stream of {:new_file,name} or uncompressed_bin
@@ -16,9 +14,10 @@ use the stream to do:
 ```elixir
 File.stream!("myfile.zip", [], 500)
 |> ZipStream.unzip
-|> Stream.reduce(nil,fn 
+|>Enum.reduce(nil,fn 
   {:new_file,name},_current->name
-  binary,file_name->
+  :nomore_files,_current->nil
+  binary_chunk,file_name->
     #DO SOMTHING WITH the binary chunk of file_name
     file_name
 end)
@@ -26,12 +25,13 @@ end)
 
 An other example: your zip contains only one file, in this case you
 can simply do the following to get a standard binary stream of this
-on file. (drop the `{:new_file,_}` of the single file)
+on file. (drop the `{:new_file,_}` of the single file, and the last `:nomore_files` atom)
 
 ```elixir
 binstream = File.stream!("myfile.zip", [], 500)
 |> ZipStream.unzip
 |> Stream.drop(1)
+|> Stream.drop(-1)
 ```
 
 ## Known Limitations

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
-# ZipStream
+# ZipStream [![Build Status](https://api.travis-ci.org/awetzel/zip_stream.svg)][Continuous Integration]
+
+[Continuous Integration]: http://travis-ci.org/awetzel/zip_stream "Build status by Travis-CI"
 
 Library to read zip file in a stream.
-Zip file binary stream -> stream of {:new_file,name} or uncompressed_bin
+Zip file binary stream -> stream of {:new_file,name} or uncompressed_bin or :nomore_files
 
 Erlang zlib library only allows deflate decompress stream.  But
 Erlang zip library does not allow content streaming.

--- a/lib/zip_stream.ex
+++ b/lib/zip_stream.ex
@@ -11,7 +11,7 @@ defmodule ZipStream do
     :zlib.inflateInit(z,-15)
     zip(z,:data,binsize,rest, name, [[{:new_file,name}]|acc])
   end
-  defp zip(z,:header,<<0x50,0x4b,0x01,0x02,_::binary>>=bin,acc), do: {endacc(acc),{z,:nomore_files}}
+  defp zip(z,:header,<<0x50,0x4b,0x01,0x02,_::binary>>=bin,acc), do: {endacc([[:nomore_files] | acc]),{z,:nomore_files}}
   defp zip(z,:header,bin,acc), do: {endacc(acc),{z,{:inheader,bin}}}
 
   defp zip(z,:data,0,rest, _, acc), do: zip(z,:header,rest,acc)

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ZipStream.Mixfile do
 
   def project do
     [app: :zip_stream,
-     version: "0.1.0",
+     version: "0.2.0",
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,


### PR DESCRIPTION
Currently, {:new_file, nil} is not returned after the last file, this makes it difficult for downstream to know that the last chunk has been received. This means that the downstream cannot return an item indicating that all binary chunks of the last file have been fully received/processes.

For example, if using after_fun in `ZipStream.unzip |> Stream.transform`, there would be no way to return, `{:ok, file_name}` indicating that the last file is complete.
